### PR TITLE
TextAsset bytes handling

### DIFF
--- a/src/XUnity.AutoTranslator.Plugin.Core/AssetRedirection/TextAndEncoding.cs
+++ b/src/XUnity.AutoTranslator.Plugin.Core/AssetRedirection/TextAndEncoding.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Collections.Generic;
+using System.Text;
 
 namespace XUnity.AutoTranslator.Plugin.Core.AssetRedirection
 {
@@ -7,16 +8,20 @@ namespace XUnity.AutoTranslator.Plugin.Core.AssetRedirection
    /// </summary>
    public class TextAndEncoding
    {
-      /// <summary>
-      /// Constructs a new text with encoding.
-      /// </summary>
-      /// <param name="text"></param>
-      /// <param name="encoding"></param>
-      public TextAndEncoding( string text, Encoding encoding )
+      /// <summary>Constructs a new text with encoding.</summary>
+      /// <param name="text"/>
+      /// <param name="encoding">Encoding to be use when auto-encoding <c>Text</c> into <c>Bytes</c> (pass <c>null</c> to disable auto-encoding)</param>
+      /// <param name="bytes"/>
+      public TextAndEncoding( string text, Encoding encoding, IEnumerable<byte> bytes = null )
       {
          Text = text;
          Encoding = encoding;
+         Bytes = bytes;
       }
+
+      /// <summary>Constructs a new text with encoding.</summary>
+      /// <param name="bytes"/>
+      public TextAndEncoding( IEnumerable<byte> bytes ) : this( null, null, bytes ) { }
 
       /// <summary>
       /// Gets the text.
@@ -24,8 +29,14 @@ namespace XUnity.AutoTranslator.Plugin.Core.AssetRedirection
       public string Text { get; }
 
       /// <summary>
-      /// Gets the encoding the text is supposed to be stored with.
+      ///   <para>Gets the encoding used when storing <c>Text</c> into <c>Bytes</c>.</para>
+      ///   <para><c>Bytes</c> will be left untouched if it set directly or if <c>Encoding</c> is <c>null</c>.</para>
       /// </summary>
       public Encoding Encoding { get; }
+
+      /// <summary>
+      /// Gets the bytes.
+      /// </summary>
+      public IEnumerable<byte> Bytes { get;  }
    }
 }

--- a/src/XUnity.AutoTranslator.Plugin.Core/AssetRedirection/TextAssetLoadedHandlerBase.cs
+++ b/src/XUnity.AutoTranslator.Plugin.Core/AssetRedirection/TextAssetLoadedHandlerBase.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Linq;
 using UnityEngine;
 using XUnity.AutoTranslator.Plugin.Core.Hooks;
 using XUnity.Common.Utilities;
@@ -46,17 +47,20 @@ namespace XUnity.AutoTranslator.Plugin.Core.AssetRedirection
          {
             var ext = asset.GetOrCreateExtensionData<TextAssetExtensionData>();
 
-            // Using a StreamWriter rather than just encoding.GetBytes() will also allow it to output BOM, if required by the game
-            var stream = new MemoryStream();
-            using( var writer = new StreamWriter( stream, info.Encoding ) )
-            {
-               writer.Write( info.Text );
-               writer.Flush();
-            }
-
             ext.Text = info.Text;
-            ext.Data = stream.ToArray();
+            ext.Data = info.Bytes?.ToArray();
 
+            if( ext.Data is null && info.Encoding != null && info.Text != null )
+            {
+               // Using a StreamWriter rather than just encoding.GetBytes() will also allow it to output BOM, if required by the game
+               var stream = new MemoryStream();
+               using( var writer = new StreamWriter( stream, info.Encoding ) )
+               {
+                  writer.Write( info.Text );
+                  writer.Flush();
+               }
+               ext.Data = stream.ToArray();
+            }
             return true;
          }
 


### PR DESCRIPTION
Allow setting `TextAsset.bytes` directly and leave `TextAsset.text` as `null`.