### PR TITLE
TexstAsset handling updates

### DIFF
--- a/src/XUnity.AutoTranslator.Plugin.Core/AssetRedirection/TextAssetLoadedHandlerBase.cs
+++ b/src/XUnity.AutoTranslator.Plugin.Core/AssetRedirection/TextAssetLoadedHandlerBase.cs
@@ -46,10 +46,8 @@ namespace XUnity.AutoTranslator.Plugin.Core.AssetRedirection
          if( info != null )
          {
             var ext = asset.GetOrCreateExtensionData<TextAssetExtensionData>();
-            ext.Encoding = info.Encoding;
-            ext.Text = info.Text;
+            ext.Encoding = info.Encoding ?? Encoding.UTF8;
             ext.Data = info.Bytes;
-
             return true;
          }
 


### PR DESCRIPTION
- Updated `TextAndEncoding` and `TextAssetExtensionData` to only store bytes
     - Setting bytes directly does a round-trip check (if it fails accessing text will return null)
- no longer have to do `ext.Text = info.Text` in `TextAssetLoadedHandlerBase.ReplaceOrUpdateAsset` since bytes covers both.