### PR TITLE
fix friendly key appeared in translation cache in some cases

### DIFF
--- a/src/XUnity.AutoTranslator.Plugin.Core/TemplatedString.cs
+++ b/src/XUnity.AutoTranslator.Plugin.Core/TemplatedString.cs
@@ -55,46 +55,33 @@ namespace XUnity.AutoTranslator.Plugin.Core
 
       public static string ReplaceApproximateMatches( string translatedText, string translatorFriendlyKey, string key )
       {
-         var cidx = 0;
-         var startIdx = 0;
+            var tfKeyMaxIndex = translatorFriendlyKey.Length - 1;
+            var cidx = tfKeyMaxIndex;
+            var endIndex = tfKeyMaxIndex;
 
-         for( int i = 0; i < translatedText.Length; i++ )
-         {
-            var c = translatedText[ i ];
-            if( c == ' ' || c == '　' ) continue;
-            
-            if( char.ToUpperInvariant( c ) == char.ToUpperInvariant( translatorFriendlyKey[ cidx ] ) )
+            var maxIndex = translatedText.Length - 1;
+            for (int i = maxIndex; i >= 0; i--)
             {
-               if( cidx == 0 )
-               {
-                  startIdx = i;
-               }
+                var c = translatedText[i];
+                if (c == ' ' || c == '　') continue;
 
-               cidx++;
+                if ((c = char.ToUpperInvariant(c)) == char.ToUpperInvariant(translatorFriendlyKey[cidx])
+                    || c == char.ToUpperInvariant(translatorFriendlyKey[cidx = tfKeyMaxIndex]))
+                {
+                    if (cidx == tfKeyMaxIndex) endIndex = i;
+
+                    cidx--;
+                }
+
+                if (cidx >= 0) continue;
+
+                var lengthOfFriendlyKeyPlusSpaces = (endIndex + 1) - i;
+                translatedText = translatedText.Remove(i, lengthOfFriendlyKeyPlusSpaces).Insert(i, key);
+
+                cidx = tfKeyMaxIndex;
             }
-            else
-            {
-               cidx = 0;
-               startIdx = 0;
-            }
 
-            if( cidx == translatorFriendlyKey.Length )
-            {
-               int endIdx = i + 1;
-
-               var lengthOfKey = endIdx - startIdx;
-               var diff = lengthOfKey - key.Length;
-
-               translatedText = translatedText.Remove( startIdx, lengthOfKey ).Insert( startIdx, key );
-
-               i -= diff;
-
-               cidx = 0;
-               startIdx = 0;
-            }
-         }
-
-         return translatedText;
+            return translatedText;
       }
    }
 }


### PR DESCRIPTION
actually it is very old issue
zmcz, zmdz or kind of can appear in translation cache when some zz combinations of translation text
tested fixed variant with many different variants of text and it replaced correctly in all cases when original failed
also search was changed to negative search to reduce code amount and prevent possible incorrect position calculations after replacing identical key several times