### PR TITLE
Complete the introduction of Baidu Translate in README and change the endpoint to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ The supported translators are:
  * [Sugoi Translator](https://github.com/Vin-meido/XUnity-AutoTranslator-SugoiOfflineTranslatorEndpoint), currently requires external translator plugin.
    * No limitations. Remarkable quality.
  * [LingoCloudTranslate](https://anonym.to/?https://fanyi.caiyunapp.com/), based on the online LingoCloud translation service. Translation is only supported in Chinese and two other languages: Japanese and English.
-   * Not sure on quotas on this one.
+   * After registration and free certification, the first 1 million characters per month are free, and the excess will be charged at 20 yuan/million characters.The official test token is `3975l6lr5pcbvidl6jl2`, you can try it before registering.
  * CustomTranslate. Alternatively you can also specify any custom HTTP url that can be used as a translation endpoint (GET request). This must use the query parameters "from", "to" and "text" and return only a string with the result (try HTTP without SSL first, as unity-mono often has issues with SSL).
    * *NOTE: This is a developer-centric option. You cannot simply specify "CustomTranslate" and expect it to work with any arbitrary translation service you find online. See [FAQ](#frequently-asked-questions)*
    * Example Configuration:

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ The supported translators are:
  * [PapagoTranslate](https://anonym.to/?https://papago.naver.com/), based on the online Papago translation service. Does not require authentication.
    * No limitations, but unstable.
  * [BaiduTranslate](https://anonym.to/?https://fanyi.baidu.com/), based on Baidu translation service. Requires AppId and AppSecret.
-   * Not sure on quotas on this one.
+   * After registration, the first 50,000 characters per month are free (QPS=1), and 49 yuan/million characters are charged after that. If you have passed the free identity authentication, then the first 1 million characters per month are free (QPS=10), and the excess is charged at 49 yuan/million characters. The longest single request is 6000 characters.
  * [YandexTranslate](https://anonym.to/?https://tech.yandex.com/translate/), based on the Yandex translation service. Requires an API key.
    * Free up to 1 million characters per day, but max 10 million characters per month.
  * [WatsonTranslate](https://anonym.to/?https://cloud.ibm.com/apidocs/language-translator), based on IBM's Watson. Requires a URL and an API key.

--- a/src/Translators/BaiduTranslate/BaiduTranslateEndpoint.cs
+++ b/src/Translators/BaiduTranslate/BaiduTranslateEndpoint.cs
@@ -79,7 +79,7 @@ namespace BaiduTranslate
          { "hu", "hu" },
       };
 
-      private static readonly string HttpServicePointTemplateUrl = "http://api.fanyi.baidu.com/api/trans/vip/translate?q={0}&from={1}&to={2}&appid={3}&salt={4}&sign={5}";
+      private static readonly string HttpServicePointTemplateUrl = "https://api.fanyi.baidu.com/api/trans/vip/translate?q={0}&from={1}&to={2}&appid={3}&salt={4}&sign={5}";
       private static readonly MD5 HashMD5 = MD5.Create();
 
       private string _appId;

--- a/src/Translators/LingoCloudTranslate/LingoCloudTranslateEndPoint.cs
+++ b/src/Translators/LingoCloudTranslate/LingoCloudTranslateEndPoint.cs
@@ -49,7 +49,7 @@ namespace LingoCloudTranslate
          _token = context.GetOrCreateSetting( "LingoCloud", "LingoCloudToken", "" );
          if( string.IsNullOrEmpty( _token ) ) throw new EndpointInitializationException( "The LingoCloudTranslate endpoint requires an App Id which has not been provided." );
 
-         context.DisableCertificateChecksFor( "https://api.interpreter.caiyunai.com/v1/translator" );
+         context.DisableCertificateChecksFor( "api.interpreter.caiyunai.com" );
 
          if( !SupportedLanguages.ContainsKey( context.SourceLanguage ) ) throw new EndpointInitializationException( $"The source language '{context.SourceLanguage}' is not supported." );
          if( !SupportedLanguages.ContainsKey( context.DestinationLanguage ) ) throw new EndpointInitializationException( $"The destination language '{context.DestinationLanguage}' is not supported." );
@@ -70,7 +70,6 @@ namespace LingoCloudTranslate
 
          var request = new XUnityWebRequest( "POST", HttpServicePointTemplateUrl, data );
          request.Headers[ HttpRequestHeader.ContentType ] = "application/json";
-         request.Headers[ HttpRequestHeader.Accept ] = "application/json";
          request.Headers[ "X-Authorization" ] = $"token {this._token}";
 
          context.Complete( request );

--- a/src/Translators/LingoCloudTranslate/LingoCloudTranslateEndPoint.cs
+++ b/src/Translators/LingoCloudTranslate/LingoCloudTranslateEndPoint.cs
@@ -36,7 +36,7 @@ namespace LingoCloudTranslate
          return lang;
       }
 
-      private static readonly string HttpServicePointTemplateUrl = "http://api.interpreter.caiyunai.com/v1/translator";
+      private static readonly string HttpServicePointTemplateUrl = "https://api.interpreter.caiyunai.com/v1/translator";
 
       public override string Id => "LingoCloudTranslate";
 
@@ -47,9 +47,9 @@ namespace LingoCloudTranslate
       public override void Initialize( IInitializationContext context )
       {
          _token = context.GetOrCreateSetting( "LingoCloud", "LingoCloudToken", "" );
-         if( string.IsNullOrEmpty( _token ) ) throw new EndpointInitializationException( "The BaiduTranslate endpoint requires an App Id which has not been provided." );
+         if( string.IsNullOrEmpty( _token ) ) throw new EndpointInitializationException( "The LingoCloudTranslate endpoint requires an App Id which has not been provided." );
 
-         context.DisableCertificateChecksFor( "http://api.interpreter.caiyunai.com/v1/translator" );
+         context.DisableCertificateChecksFor( "https://api.interpreter.caiyunai.com/v1/translator" );
 
          if( !SupportedLanguages.ContainsKey( context.SourceLanguage ) ) throw new EndpointInitializationException( $"The source language '{context.SourceLanguage}' is not supported." );
          if( !SupportedLanguages.ContainsKey( context.DestinationLanguage ) ) throw new EndpointInitializationException( $"The destination language '{context.DestinationLanguage}' is not supported." );


### PR DESCRIPTION
Is there any particular reason to use http? If not, I think we should use https.

I also added the description of the cost of Baidu Translate and LingoCloud Translate in the README.

Sorry for messing up the last PR.