### PR TITLE
InvalidOperationException handling

### DIFF
--- a/src/XUnity.AutoTranslator.Plugin.Core/AutoTranslationPlugin.cs
+++ b/src/XUnity.AutoTranslator.Plugin.Core/AutoTranslationPlugin.cs
@@ -2726,6 +2726,11 @@ namespace XUnity.AutoTranslator.Plugin.Core
                _inputSupported = false;
                XuaLogger.AutoTranslator.Warn( e, "Input API is not available!" );
             }
+            catch( InvalidOperationException e )
+            {
+               _inputSupported = false;
+               XuaLogger.AutoTranslator.Warn( e, "Input API is not available!" );
+            }
          }
       }
 


### PR DESCRIPTION
InvalidOperationException handling for games that use new Input System instead of UnityEngine.Input to prevent console log spam