### PR TITLE
Use reflection to access Il2CppInteropManager.IL2CPPInteropAssemblyPath

### DIFF
--- a/src/XUnity.AutoTranslator.Plugin.BepInEx-IL2CPP/AutoTranslatorPlugin.cs
+++ b/src/XUnity.AutoTranslator.Plugin.BepInEx-IL2CPP/AutoTranslatorPlugin.cs
@@ -31,7 +31,23 @@ namespace XUnity.AutoTranslator.Plugin.BepInEx
 
          _configPath = Path.Combine( ConfigPath, "AutoTranslatorConfig.ini" );
 
-         Il2CppProxyAssemblies.Location = Path.Combine( Paths.BepInExRootPath, "interop" ); // Il2CppInteropManager.IL2CPPInteropAssemblyPath is internal...
+         Il2CppProxyAssemblies.Location = GetIL2CPPInteropAssemblyPath();
+      }
+
+      private string GetIL2CPPInteropAssemblyPath()
+      {
+         // Il2CppInteropManager.IL2CPPInteropAssemblyPath is internal...
+         try
+         {
+            var Il2CppInteropManagerType = Type.GetType( "BepInEx.Unity.IL2CPP.Il2CppInteropManager, BepInEx.Unity.IL2CPP" );
+            Log.LogInfo( Il2CppInteropManagerType );
+            return (string)Il2CppInteropManagerType.GetProperty( "IL2CPPInteropAssemblyPath", BindingFlags.Static | BindingFlags.NonPublic ).GetValue( null );
+         }
+         catch( Exception e )
+         {
+            Log.LogError( e );
+            return Path.Combine( Paths.BepInExRootPath, "interop" );
+         }
       }
 
       public override void Load()

--- a/src/XUnity.AutoTranslator.Plugin.BepInEx-IL2CPP/AutoTranslatorPlugin.cs
+++ b/src/XUnity.AutoTranslator.Plugin.BepInEx-IL2CPP/AutoTranslatorPlugin.cs
@@ -40,8 +40,7 @@ namespace XUnity.AutoTranslator.Plugin.BepInEx
          try
          {
             var Il2CppInteropManagerType = Type.GetType( "BepInEx.Unity.IL2CPP.Il2CppInteropManager, BepInEx.Unity.IL2CPP" );
-            Log.LogInfo( Il2CppInteropManagerType );
-            return (string)Il2CppInteropManagerType.GetProperty( "IL2CPPInteropAssemblyPath", BindingFlags.Static | BindingFlags.NonPublic ).GetValue( null );
+            return (string)Il2CppInteropManagerType.GetProperty( "IL2CPPInteropAssemblyPath", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public ).GetValue( null );
          }
          catch( Exception e )
          {


### PR DESCRIPTION
Don't know when the Il2CppInteropManager.IL2CPPInteropAssemblyPath is added to BepInEx. Only tested in BepInEx 6.0.0-be.680