### PR TITLE
Allow DeepLTranslator supports `auto`

### DIFF
--- a/src/Translators/DeepLTranslate.ExtProtocol/ExtDeepLTranslateLegitimate.cs
+++ b/src/Translators/DeepLTranslate.ExtProtocol/ExtDeepLTranslateLegitimate.cs
@@ -115,7 +115,9 @@ namespace DeepLTranslate.ExtProtocol
 
          var parameters = new List<KeyValuePair<string, string>>();
          parameters.Add( new KeyValuePair<string, string>( "auth_key", _apiKey ) );
-         parameters.Add( new KeyValuePair<string, string>( "source_lang", FixLanguage( context.SourceLanguage ).ToUpperInvariant() ) );
+         if( !string.Equals(context.SourceLanguage, "auto", StringComparison.OrdinalIgnoreCase) ) {
+            parameters.Add( new KeyValuePair<string, string>( "source_lang", FixLanguage( context.SourceLanguage ).ToUpperInvariant() ) );
+         }
          parameters.Add( new KeyValuePair<string, string>( "target_lang", FixLanguage( context.DestinationLanguage ).ToUpperInvariant() ) );
          parameters.Add( new KeyValuePair<string, string>( "split_sentences", "1" ) );
 

--- a/src/Translators/DeepLTranslate/DeepLTranslateLegitimate.cs
+++ b/src/Translators/DeepLTranslate/DeepLTranslateLegitimate.cs
@@ -17,7 +17,7 @@ namespace DeepLTranslate
    {
       private static readonly HashSet<string> SupportedLanguages = new HashSet<string>
       {
-         "bg", "cs", "da", "de", "el", "en", "es", "et", "fi", "fr", "hu", "it", "ja", "lt", "lv", "nl", "pl", "pt", "ro", "ru", "sk", "sl", "sv", "zh", "ko"
+         "auto", "bg", "cs", "da", "de", "el", "en", "es", "et", "fi", "fr", "hu", "it", "ja", "lt", "lv", "nl", "pl", "pt", "ro", "ru", "sk", "sl", "sv", "zh", "ko"
       };
 
       public override string Id => "DeepLTranslateLegitimate";


### PR DESCRIPTION
According to https://developers.deepl.com/docs/api-reference/translate/openapi-spec-for-text-translation

`source_lang` is optional, and DeepL will auto-detect language if it's not given.

Note: I don't have Unity or C# development environment, so I can't compile it, but the code is simple