### PR TITLE
Fix HandleInputSafe crashing in some games

### DIFF
--- a/src/XUnity.AutoTranslator.Plugin.Core/AutoTranslationPlugin.cs
+++ b/src/XUnity.AutoTranslator.Plugin.Core/AutoTranslationPlugin.cs
@@ -2721,7 +2721,7 @@ namespace XUnity.AutoTranslator.Plugin.Core
             {
                HandleInput();
             }
-            catch( TypeLoadException e )
+            catch( Exception e )
             {
                _inputSupported = false;
                XuaLogger.AutoTranslator.Warn( e, "Input API is not available!" );


### PR DESCRIPTION
In some cases input API can throw an InvalidOperationException, resulting in error spam on every frame. I don't see any reason to catch only specific Exceptions, they are logged and the end result is the same - Input API isn't usable.

Full exception message: System.InvalidOperationException: You are trying to read Input using the UnityEngine.Input class, but you have switched active Input handling to Input System package in Player Settings.