### PR TITLE
OS Independent Paths

### DIFF
--- a/src/XUnity.AutoTranslator.Plugin.MelonMod/AutoTranslatorPlugin.cs
+++ b/src/XUnity.AutoTranslator.Plugin.MelonMod/AutoTranslatorPlugin.cs
@@ -26,7 +26,7 @@ namespace XUnity.AutoTranslator.Plugin.MelonMod
 #if IL2CPP
          var modFi = new FileInfo( Location );
          var gameDir = modFi.Directory.Parent;
-         var unhollowedPath = Path.Combine( gameDir.FullName, @"MelonLoader\Il2CppAssemblies" );
+         var unhollowedPath = Path.Combine( gameDir.FullName, "MelonLoader","Il2CppAssemblies" );
          Il2CppProxyAssemblies.Location = unhollowedPath;
 #endif
 


### PR DESCRIPTION
Since there is a port of Melon Loader for Android. AutoTranslator is working but only failing to store the translations due to "\" notation which is not supported in Android(linux) so to make is OS independent have made the given changes.