### PR TITLE
Translation scoping - if GetScopeFromComponent fails, use GetActiveSceneId instead of -1

### DIFF
--- a/src/XUnity.AutoTranslator.Plugin.Core/Utilities/TranslationScopeHelper.cs
+++ b/src/XUnity.AutoTranslator.Plugin.Core/Utilities/TranslationScopeHelper.cs
@@ -20,10 +20,15 @@ namespace XUnity.AutoTranslator.Plugin.Utilities
          {
             try
             {
+               var GetScopeReturn = -1;
                if( ui is Component component && component )
                {
-                  return GetScopeFromComponent( component );
+                  GetScopeReturn = GetScopeFromComponent( component );
                }
+               if( GetScopeReturn != -1 )
+			      {
+				      return GetScopeReturn; 
+			      }
                else if( ui is GUIContent guic ) // not same as spamming component because we allow nulls
                {
                   return TranslationScopes.None;


### PR DESCRIPTION
https://github.com/bbepis/XUnity.AutoTranslator/issues/617