### PR TITLE
Move XZipper from DotNetZip to SharpCompress

### DIFF
--- a/src/XZipper/Program.cs
+++ b/src/XZipper/Program.cs
@@ -1,7 +1,10 @@
-﻿using Ionic.Zip;
-using Ionic.Zlib;
-using System;
-using System.IO;
+﻿using System.IO;
+using System.Text;
+using SharpCompress.Archives;
+using SharpCompress.Archives.Zip;
+using SharpCompress.Common;
+using SharpCompress.Compressors.Deflate;
+using SharpCompress.Writers.Zip;
 
 namespace XZipper
 {
@@ -14,12 +17,12 @@ namespace XZipper
             File.Delete( args[ 1 ] );
          }
 
-         using( ZipFile zip = new ZipFile( args[ 1 ] ) )
+         using( var zip = ZipArchive.Create() )
          {
-            zip.CompressionLevel = CompressionLevel.BestCompression;
+            zip.DeflateCompressionLevel = CompressionLevel.BestCompression;
 
-            zip.AddDirectory( args[ 0 ] );
-            zip.Save();
+            zip.AddAllFromDirectory( args[ 0 ] );
+            zip.SaveTo( args[ 1 ], new ZipWriterOptions( CompressionType.Deflate ) { ArchiveEncoding = new ArchiveEncoding( Encoding.UTF8, Encoding.UTF8 ), CompressionType = CompressionType.Deflate, DeflateCompressionLevel = CompressionLevel.BestCompression, UseZip64 = false } );
          }
       }
    }

--- a/src/XZipper/XZipper.csproj
+++ b/src/XZipper/XZipper.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNetZip" Version="1.13.6" />
+    <PackageReference Include="SharpCompress" Version="0.38.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
DotNetZip is no longer maintained and has security issues that cause a bunch of warnings all over the place.