### PR TITLE
Replace culture sensitive string operations with invariant or ordinal

### DIFF
--- a/src/Translators/BingTranslate/BingTranslateEndpoint.cs
+++ b/src/Translators/BingTranslate/BingTranslateEndpoint.cs
@@ -262,11 +262,11 @@ namespace BingTranslate
 
       private string Lookup( string lookFor, string html )
       {
-         var index = html.IndexOf( lookFor );
+         var index = html.IndexOf( lookFor, StringComparison.Ordinal );
          if( index > -1 ) // simple string approach
          {
             var startIndex = index + lookFor.Length;
-            var endIndex = html.IndexOf( "\"", startIndex );
+            var endIndex = html.IndexOf( '\"', startIndex );
 
             if( startIndex > -1 && endIndex > -1 )
             {

--- a/src/Translators/Common.ExtProtocol/Utilities/SimpleJson.cs
+++ b/src/Translators/Common.ExtProtocol/Utilities/SimpleJson.cs
@@ -245,7 +245,7 @@ namespace SimpleJSON
          get
          {
             double v = 0.0;
-            if( double.TryParse( Value, NumberStyles.None, CultureInfo.InvariantCulture, out v ) )
+            if( double.TryParse( Value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out v ) )
                return v;
             return 0.0;
          }
@@ -940,7 +940,7 @@ namespace SimpleJSON
          set
          {
             double v;
-            if( double.TryParse( value, NumberStyles.None, CultureInfo.InvariantCulture, out v ) )
+            if( double.TryParse( value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out v ) )
                m_Data = v;
          }
       }

--- a/src/Translators/Common.ExtProtocol/Utilities/SimpleJson.cs
+++ b/src/Translators/Common.ExtProtocol/Utilities/SimpleJson.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 
@@ -244,13 +245,13 @@ namespace SimpleJSON
          get
          {
             double v = 0.0;
-            if( double.TryParse( Value, out v ) )
+            if( double.TryParse( Value, NumberStyles.None, CultureInfo.InvariantCulture, out v ) )
                return v;
             return 0.0;
          }
          set
          {
-            Value = value.ToString();
+            Value = value.ToString(CultureInfo.InvariantCulture);
          }
       }
 
@@ -935,11 +936,11 @@ namespace SimpleJSON
 
       public override string Value
       {
-         get { return m_Data.ToString(); }
+         get { return m_Data.ToString(CultureInfo.InvariantCulture); }
          set
          {
             double v;
-            if( double.TryParse( value, out v ) )
+            if( double.TryParse( value, NumberStyles.None, CultureInfo.InvariantCulture, out v ) )
                m_Data = v;
          }
       }

--- a/src/Translators/GoogleTranslate/GoogleTranslateEndpoint.cs
+++ b/src/Translators/GoogleTranslate/GoogleTranslateEndpoint.cs
@@ -337,11 +337,11 @@ namespace GoogleTranslate
             string[] lookups = new[] { "tkk:'", "TKK='" };
             foreach( var lookup in lookups )
             {
-               var index = html.IndexOf( lookup );
+               var index = html.IndexOf( lookup, StringComparison.Ordinal );
                if( index > -1 ) // simple string approach
                {
                   var startIndex = index + lookup.Length;
-                  var endIndex = html.IndexOf( "'", startIndex );
+                  var endIndex = html.IndexOf( '\'', startIndex );
                   var result = html.Substring( startIndex, endIndex - startIndex );
 
                   var parts = result.Split( '.' );

--- a/src/Translators/GoogleTranslate/GoogleTranslateEndpointV2.cs
+++ b/src/Translators/GoogleTranslate/GoogleTranslateEndpointV2.cs
@@ -175,7 +175,7 @@ namespace GoogleTranslate
 
          // output is some odd form of chunked-encoding. We just look at the first chunk
          data = data.Substring( 6 );
-         var chars = data.Substring( 0, data.IndexOf( "\n" ) );
+         var chars = data.Substring( 0, data.IndexOf( '\n' ) );
          var num = int.Parse( chars, CultureInfo.InvariantCulture );
          data = data.Substring( chars.Length, num );
 
@@ -355,11 +355,11 @@ namespace GoogleTranslate
             string[] lookups = new[] { "FdrFJe\":\"" };
             foreach( var lookup in lookups )
             {
-               var index = html.IndexOf( lookup );
+               var index = html.IndexOf( lookup, StringComparison.Ordinal );
                if( index > -1 ) // simple string approach
                {
                   var startIndex = index + lookup.Length;
-                  var endIndex = html.IndexOf( "\"", startIndex );
+                  var endIndex = html.IndexOf( '\"', startIndex );
                   var result = html.Substring( startIndex, endIndex - startIndex );
 
                   _FSID = long.Parse( result, CultureInfo.InvariantCulture );

--- a/src/Translators/GoogleTranslateCompat.ExtProtocol/GoogleTranslateCompatTranslate.cs
+++ b/src/Translators/GoogleTranslateCompat.ExtProtocol/GoogleTranslateCompatTranslate.cs
@@ -238,11 +238,11 @@ namespace GoogleTranslateCompat.ExtProtocol
             string[] lookups = new[] { "tkk:'", "TKK='" };
             foreach( var lookup in lookups )
             {
-               var index = html.IndexOf( lookup );
+               var index = html.IndexOf( lookup, StringComparison.Ordinal );
                if( index > -1 ) // simple string approach
                {
                   var startIndex = index + lookup.Length;
-                  var endIndex = html.IndexOf( "'", startIndex );
+                  var endIndex = html.IndexOf( '\'', startIndex );
                   var result = html.Substring( startIndex, endIndex - startIndex );
 
                   var parts = result.Split( '.' );

--- a/src/Translators/PapagoTranslate/PapagoTranslateEndpoint.cs
+++ b/src/Translators/PapagoTranslate/PapagoTranslateEndpoint.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Security.Cryptography;
@@ -111,7 +112,7 @@ namespace PapagoTranslate
          request.Headers[ HttpRequestHeader.UserAgent ] = string.IsNullOrEmpty( AutoTranslatorSettings.UserAgent ) ? UserAgents.Chrome_Win10_Latest : AutoTranslatorSettings.UserAgent;
          request.Headers[ "Authorization" ] = $"PPG {UUID}:{token}";
          request.Headers[ "Content-Type" ] = "application/x-www-form-urlencoded; charset=UTF-8";
-         request.Headers[ "Timestamp" ] = timestamp.ToString();
+         request.Headers[ "Timestamp" ] = timestamp.ToString(CultureInfo.InvariantCulture);
 
          context.Complete( request );
 

--- a/src/UnityEngine/WWW.cs
+++ b/src/UnityEngine/WWW.cs
@@ -265,7 +265,7 @@ namespace UnityEngine
                continue;
             }
 
-            int num2 = text.IndexOf( ": " );
+            int num2 = text.IndexOf( ": ", StringComparison.Ordinal );
             if( num2 != -1 )
             {
                string key = text.Substring( 0, num2 ).ToUpper();

--- a/src/XUnity.AutoTranslator.Plugin.Core/Json/SimpleJson.cs
+++ b/src/XUnity.AutoTranslator.Plugin.Core/Json/SimpleJson.cs
@@ -245,7 +245,7 @@ namespace SimpleJSON
          get
          {
             double v = 0.0;
-            if( double.TryParse( Value, NumberStyles.None, CultureInfo.InvariantCulture, out v ) )
+            if( double.TryParse( Value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out v ) )
                return v;
             return 0.0;
          }
@@ -940,7 +940,7 @@ namespace SimpleJSON
          set
          {
             double v;
-            if( double.TryParse( value, NumberStyles.None, CultureInfo.InvariantCulture, out v ) )
+            if( double.TryParse( value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out v ) )
                m_Data = v;
          }
       }

--- a/src/XUnity.AutoTranslator.Plugin.Core/Json/SimpleJson.cs
+++ b/src/XUnity.AutoTranslator.Plugin.Core/Json/SimpleJson.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 
@@ -244,13 +245,13 @@ namespace SimpleJSON
          get
          {
             double v = 0.0;
-            if( double.TryParse( Value, out v ) )
+            if( double.TryParse( Value, NumberStyles.None, CultureInfo.InvariantCulture, out v ) )
                return v;
             return 0.0;
          }
          set
          {
-            Value = value.ToString();
+            Value = value.ToString(CultureInfo.InvariantCulture);
          }
       }
 
@@ -935,11 +936,11 @@ namespace SimpleJSON
 
       public override string Value
       {
-         get { return m_Data.ToString(); }
+         get { return m_Data.ToString(CultureInfo.InvariantCulture); }
          set
          {
             double v;
-            if( double.TryParse( value, out v ) )
+            if( double.TryParse( value, NumberStyles.None, CultureInfo.InvariantCulture, out v ) )
                m_Data = v;
          }
       }

--- a/src/XUnity.AutoTranslator.Plugin.Core/TextureTranslationCache.cs
+++ b/src/XUnity.AutoTranslator.Plugin.Core/TextureTranslationCache.cs
@@ -210,8 +210,8 @@ namespace XUnity.AutoTranslator.Plugin.Core
          try
          {
             var fileName = Path.GetFileNameWithoutExtension( fullFileName );
-            var startHash = fileName.LastIndexOf( "[" );
-            var endHash = fileName.LastIndexOf( "]" );
+            var startHash = fileName.LastIndexOf( '[' );
+            var endHash = fileName.LastIndexOf( ']' );
 
             if( endHash > -1 && startHash > -1 && endHash > startHash )
             {

--- a/src/XUnity.AutoTranslator.Plugin.Core/TranslationFileLoadingContext.cs
+++ b/src/XUnity.AutoTranslator.Plugin.Core/TranslationFileLoadingContext.cs
@@ -228,7 +228,7 @@ namespace XUnity.AutoTranslator.Plugin.Core
    {
       public static TranslationFileDirective Create( string directive )
       {
-         var commentIndex = directive.IndexOf( '/' );
+         var commentIndex = directive.IndexOf( "//", StringComparison.Ordinal );
          if( commentIndex > -1 )
          {
             directive = directive.Substring( 0, commentIndex );

--- a/src/XUnity.AutoTranslator.Plugin.Core/TranslationFileLoadingContext.cs
+++ b/src/XUnity.AutoTranslator.Plugin.Core/TranslationFileLoadingContext.cs
@@ -228,7 +228,7 @@ namespace XUnity.AutoTranslator.Plugin.Core
    {
       public static TranslationFileDirective Create( string directive )
       {
-         var commentIndex = directive.IndexOf( "//" );
+         var commentIndex = directive.IndexOf( '/' );
          if( commentIndex > -1 )
          {
             directive = directive.Substring( 0, commentIndex );
@@ -245,7 +245,7 @@ namespace XUnity.AutoTranslator.Plugin.Core
                var command = parts[ 0 ].ToLowerInvariant();
 
                var setType = parts[ 1 ];
-               var argument = directive.Substring( directive.IndexOf( setType ) + setType.Length ).Trim();
+               var argument = directive.Substring( directive.IndexOf( setType, StringComparison.Ordinal ) + setType.Length ).Trim();
                setType = setType.ToLowerInvariant();
                switch( command )
                {

--- a/src/XUnity.AutoTranslator.Plugin.Core/Utilities/TemplatingHelper.cs
+++ b/src/XUnity.AutoTranslator.Plugin.Core/Utilities/TemplatingHelper.cs
@@ -78,7 +78,7 @@ namespace XUnity.AutoTranslator.Plugin.Core.Utilities
             if( string.IsNullOrEmpty( replacement ) )
             {
                int idx = -1;
-               while( ( idx = str.IndexOf( original ) ) != -1 )
+               while( ( idx = str.IndexOf( original, StringComparison.InvariantCulture ) ) != -1 )
                {
                   succeeded = true;
                   str = str.Remove( idx, original.Length );
@@ -88,7 +88,7 @@ namespace XUnity.AutoTranslator.Plugin.Core.Utilities
             {
                string key = null;
                int idx = -1;
-               while( ( idx = str.IndexOf( original ) ) != -1 )
+               while( ( idx = str.IndexOf( original, StringComparison.InvariantCulture ) ) != -1 )
                {
                   if( key == null )
                   {

--- a/src/XUnity.AutoTranslator.Plugin.Core/Web/Internal/ConnectionTrackingWebClient.cs
+++ b/src/XUnity.AutoTranslator.Plugin.Core/Web/Internal/ConnectionTrackingWebClient.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -1794,7 +1795,7 @@ namespace XUnity.AutoTranslator.Plugin.Core.Web.Internal
       {
          byte[] buffer3;
          string strA = this.Headers[ "Content-Type" ];
-         if( ( strA != null ) && ( string.Compare( strA, urlEncodedCType, true ) != 0 ) )
+         if( ( strA != null ) && ( string.Compare( strA, urlEncodedCType, true, CultureInfo.InvariantCulture ) != 0 ) )
          {
             throw new WebException( "Content-Type header cannot be changed from its default value for this request." );
          }

--- a/src/XUnity.Common/Constants/UnityTypes.cs
+++ b/src/XUnity.Common/Constants/UnityTypes.cs
@@ -522,7 +522,7 @@ namespace XUnity.Common.Constants
             string @namespace = string.Empty;
             string typeName = null;
 
-            var lastDot = name.LastIndexOf( "." );
+            var lastDot = name.LastIndexOf( '.' );
             if( lastDot == -1 )
             {
                typeName = name;

--- a/src/XUnity.Common/Extensions/StringExtensions.cs
+++ b/src/XUnity.Common/Extensions/StringExtensions.cs
@@ -211,11 +211,11 @@ namespace XUnity.Common.Extensions
       {
          const int kNotFound = -1;
 
-         var startIdx = strSource.IndexOf( strStart );
+         var startIdx = strSource.IndexOf( strStart, StringComparison.InvariantCulture );
          if( startIdx != kNotFound )
          {
             startIdx += strStart.Length;
-            var endIdx = strSource.IndexOf( strEnd, startIdx );
+            var endIdx = strSource.IndexOf( strEnd, startIdx, StringComparison.InvariantCulture );
             if( endIdx > startIdx )
             {
                return strSource.Substring( startIdx, endIdx - startIdx );


### PR DESCRIPTION
This should have no functional difference under ja-JP and en-US cultures, but may fix some issues under other cultures that do weird things with `.` and such.