### PR TITLE
Double forward slash deserializing bug

### DIFF
--- a/src/XUnity.AutoTranslator.Plugin.Core/Utilities/TextHelper.cs
+++ b/src/XUnity.AutoTranslator.Plugin.Core/Utilities/TextHelper.cs
@@ -29,6 +29,7 @@ namespace XUnity.AutoTranslator.Plugin.Core.Utilities
             {
                switch( c )
                {
+                  case '/':
                   case '=':
                   case '\\':
                      builder.Append( c );


### PR DESCRIPTION
Addresses issue when serializing and deserializing double forward slashes. Serializing "//" turns into "\/\/", but does not get deserialized back to "//". Related to #636 and #637.