### PR TITLE
Add UIElements support

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ PostprocessorsFile=Translation\{Lang}\Text\_Postprocessors.txt      ;File that c
 
 [TextFrameworks]
 EnableUGUI=True                  ;Enable or disable UGUI translation
-EnableUIElements=True                  ;Enable or disable UIElements translation
+EnableUIElements=True            ;Enable or disable UIElements translation
 EnableNGUI=True                  ;Enable or disable NGUI translation
 EnableTextMeshPro=True           ;Enable or disable TextMeshPro translation
 EnableTextMesh=False             ;Enable or disable TextMesh translation

--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ PostprocessorsFile=Translation\{Lang}\Text\_Postprocessors.txt      ;File that c
 
 [TextFrameworks]
 EnableUGUI=True                  ;Enable or disable UGUI translation
+EnableUIElements=True                  ;Enable or disable UIElements translation
 EnableNGUI=True                  ;Enable or disable NGUI translation
 EnableTextMeshPro=True           ;Enable or disable TextMeshPro translation
 EnableTextMesh=False             ;Enable or disable TextMesh translation

--- a/src/XUnity.AutoTranslator.Plugin.Core/Configuration/Settings.cs
+++ b/src/XUnity.AutoTranslator.Plugin.Core/Configuration/Settings.cs
@@ -87,6 +87,7 @@ namespace XUnity.AutoTranslator.Plugin.Core.Configuration
       public static string TranslatorsPath;
       public static bool EnableIMGUI;
       public static bool EnableUGUI;
+      public static bool EnableUIElements;
       public static bool EnableNGUI;
       public static bool EnableTextMeshPro;
       public static bool EnableTextMesh;
@@ -230,6 +231,7 @@ namespace XUnity.AutoTranslator.Plugin.Core.Configuration
 
             EnableIMGUI = PluginEnvironment.Current.Preferences.GetOrDefault( "TextFrameworks", "EnableIMGUI", false );
             EnableUGUI = PluginEnvironment.Current.Preferences.GetOrDefault( "TextFrameworks", "EnableUGUI", true );
+            EnableUIElements = PluginEnvironment.Current.Preferences.GetOrDefault( "TextFrameworks", "EnableUIElements", true );
             EnableNGUI = PluginEnvironment.Current.Preferences.GetOrDefault( "TextFrameworks", "EnableNGUI", true );
             EnableTextMeshPro = PluginEnvironment.Current.Preferences.GetOrDefault( "TextFrameworks", "EnableTextMeshPro", true );
             EnableTextMesh = PluginEnvironment.Current.Preferences.GetOrDefault( "TextFrameworks", "EnableTextMesh", false );

--- a/src/XUnity.AutoTranslator.Plugin.Core/Extensions/ComponentExtensions.cs
+++ b/src/XUnity.AutoTranslator.Plugin.Core/Extensions/ComponentExtensions.cs
@@ -557,13 +557,6 @@ namespace XUnity.AutoTranslator.Plugin.Core.Extensions
                yield return comp;
             }
          }
-         if( Settings.EnableUIElements && UnityTypes.TextElement != null )
-         {
-            foreach( var comp in go.GetComponentsInChildren( UnityTypes.TextElement.UnityType, true ) )
-            {
-               yield return comp;
-            }
-         }
          if( Settings.EnableTextMesh && UnityTypes.TextMesh != null )
          {
             foreach( var comp in go.GetComponentsInChildren( UnityTypes.TextMesh.UnityType, true ) )

--- a/src/XUnity.AutoTranslator.Plugin.Core/Extensions/ComponentExtensions.cs
+++ b/src/XUnity.AutoTranslator.Plugin.Core/Extensions/ComponentExtensions.cs
@@ -202,6 +202,7 @@ namespace XUnity.AutoTranslator.Plugin.Core.Extensions
          var type = ui.GetUnityType();
 
          return ( Settings.EnableIMGUI && !_guiContentCheckFailed && IsGUIContentSafe( ui ) )
+            || ( Settings.EnableUIElements && UnityTypes.TextElement != null && UnityTypes.TextElement.IsAssignableFrom( type ) )
             || ( Settings.EnableUGUI && UnityTypes.Text != null && UnityTypes.Text.IsAssignableFrom( type ) )
             || ( Settings.EnableNGUI && UnityTypes.UILabel != null && UnityTypes.UILabel.IsAssignableFrom( type ) )
             || ( Settings.EnableTextMesh && UnityTypes.TextMesh != null && UnityTypes.TextMesh.IsAssignableFrom( type ) )
@@ -429,6 +430,10 @@ namespace XUnity.AutoTranslator.Plugin.Core.Extensions
             {
                return Il2CppUtilities.CreateProxyComponentWithDerivedType( ui.Pointer, UnityTypes.Text.ClrType );
             }
+            if( Settings.EnableUIElements && UnityTypes.TextElement != null && UnityTypes.TextElement.IsAssignableFrom( unityType ) )
+            {
+               return Il2CppUtilities.CreateProxyComponentWithDerivedType( ui.Pointer, UnityTypes.TextElement.ClrType );
+            }
             else if( Settings.EnableTextMesh && UnityTypes.TextMesh != null && UnityTypes.TextMesh.IsAssignableFrom( unityType ) )
             {
                return Il2CppUtilities.CreateProxyComponentWithDerivedType( ui.Pointer, UnityTypes.TextMesh.ClrType );
@@ -548,6 +553,13 @@ namespace XUnity.AutoTranslator.Plugin.Core.Extensions
          if( Settings.EnableUGUI && UnityTypes.Text != null )
          {
             foreach( var comp in go.GetComponentsInChildren( UnityTypes.Text.UnityType, true ) )
+            {
+               yield return comp;
+            }
+         }
+         if( Settings.EnableUIElements && UnityTypes.TextElement != null )
+         {
+            foreach( var comp in go.GetComponentsInChildren( UnityTypes.TextElement.UnityType, true ) )
             {
                yield return comp;
             }

--- a/src/XUnity.AutoTranslator.Plugin.Core/Hooks/HooksSetup.cs
+++ b/src/XUnity.AutoTranslator.Plugin.Core/Hooks/HooksSetup.cs
@@ -11,6 +11,7 @@ using XUnity.AutoTranslator.Plugin.Core.Extensions;
 using XUnity.AutoTranslator.Plugin.Core.Hooks.NGUI;
 using XUnity.AutoTranslator.Plugin.Core.Hooks.TextMeshPro;
 using XUnity.AutoTranslator.Plugin.Core.Hooks.UGUI;
+using XUnity.AutoTranslator.Plugin.Core.Hooks.UIElements;
 using XUnity.Common.Logging;
 using XUnity.Common.Utilities;
 
@@ -101,6 +102,17 @@ namespace XUnity.AutoTranslator.Plugin.Core.Hooks
          catch( Exception e )
          {
             XuaLogger.AutoTranslator.Error( e, "An error occurred while setting up hooks for UGUI." );
+         }
+         try
+         {
+            if( Settings.EnableUIElements )
+            {
+               HookingHelper.PatchAll( UIElementsHooks.All, Settings.ForceMonoModHooks );
+            }
+         }
+         catch( Exception e )
+         {
+            XuaLogger.AutoTranslator.Error( e, "An error occurred while setting up hooks for UIElements." );
          }
 
          try

--- a/src/XUnity.AutoTranslator.Plugin.Core/Hooks/UIElementsHooks.cs
+++ b/src/XUnity.AutoTranslator.Plugin.Core/Hooks/UIElementsHooks.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using UnityEngine;
+using XUnity.AutoTranslator.Plugin.Core.Constants;
+using XUnity.AutoTranslator.Plugin.Core.Extensions;
+using XUnity.AutoTranslator.Plugin.Core.Text;
+using XUnity.Common.Constants;
+using XUnity.Common.Extensions;
+using XUnity.Common.Harmony;
+using XUnity.Common.Logging;
+using XUnity.Common.MonoMod;
+using XUnity.Common.Utilities;
+
+namespace XUnity.AutoTranslator.Plugin.Core.Hooks.UIElements
+{
+   internal static class UIElementsHooks
+   {
+      public static readonly Type[] All = new[] {
+         typeof( TextElement_text_Hook ),
+      };
+   }
+
+   [HookingHelperPriority( HookPriority.Last )]
+   internal static class TextElement_text_Hook
+   {
+      static bool Prepare( object instance )
+      {
+         return UnityTypes.TextElement != null;
+      }
+
+      static MethodBase TargetMethod( object instance )
+      {
+         return AccessToolsShim.Property( UnityTypes.TextElement?.ClrType, "text" )?.GetSetMethod();
+      }
+
+#if MANAGED
+      static void Postfix( object __instance )
+#else
+      static void Postfix( Il2CppInterop.Runtime.InteropTypes.Il2CppObjectBase __instance )
+#endif
+      {
+#if IL2CPP
+         __instance = Il2CppUtilities.CreateProxyComponentWithDerivedType( __instance.Pointer, UnityTypes.TextElement.ClrType );
+#endif
+
+         AutoTranslationPlugin.Current.Hook_TextChanged( __instance, false );
+      }
+
+#if MANAGED
+      static Action<object, string> _original;
+
+      static void MM_Init( object detour )
+      {
+         _original = detour.GenerateTrampolineEx<Action<object, string>>();
+      }
+
+      static void MM_Detour( object __instance, string value )
+      {
+         _original( __instance, value );
+
+         Postfix( __instance );
+      }
+#endif
+   }
+}

--- a/src/XUnity.Common/Constants/UnityTypes.cs
+++ b/src/XUnity.Common/Constants/UnityTypes.cs
@@ -99,6 +99,7 @@ namespace XUnity.Common.Constants
       public static readonly TypeContainer Transform = FindType( "UnityEngine.Transform" );
       public static readonly TypeContainer TextMesh = FindType( "UnityEngine.TextMesh" );
       public static readonly TypeContainer Text = FindType( "UnityEngine.UI.Text" );
+      public static readonly TypeContainer TextElement = FindType( "UnityEngine.UIElements.TextElement" );
       public static readonly TypeContainer Image = FindType( "UnityEngine.UI.Image" );
       public static readonly TypeContainer RawImage = FindType( "UnityEngine.UI.RawImage" );
       public static readonly TypeContainer MaskableGraphic = FindType( "UnityEngine.UI.MaskableGraphic" );
@@ -310,6 +311,17 @@ namespace XUnity.Common.Constants
             public static readonly IntPtr get_text = Il2CppUtilities.GetIl2CppMethod( UnityTypes.Text?.ClassPointer, "get_text", typeof( string ) );
             public static readonly IntPtr get_supportRichText = Il2CppUtilities.GetIl2CppMethod( UnityTypes.Text?.ClassPointer, "get_supportRichText", typeof( bool ) );
             public static readonly IntPtr OnEnable = Il2CppUtilities.GetIl2CppMethod( UnityTypes.Text?.ClassPointer, "OnEnable", typeof( void ) );
+         }
+#endif
+      }
+
+      public static class TextElement_Methods
+      {
+#if IL2CPP
+         public static class IL2CPP
+         {
+            public static readonly IntPtr set_text = Il2CppUtilities.GetIl2CppMethod( UnityTypes.TextElement?.ClassPointer, "set_text", typeof( void ), typeof( string ) );
+            public static readonly IntPtr get_text = Il2CppUtilities.GetIl2CppMethod( UnityTypes.TextElement?.ClassPointer, "get_text", typeof( string ) );
          }
 #endif
       }


### PR DESCRIPTION
Adds support for hooking `UnityEngine.UIElements.TextElement`, which some newer games use.