### PR TITLE
fix: resolve font asset bundle loading failure in IL2CPP

### DIFF
--- a/src/XUnity.AutoTranslator.Plugin.Core/Fonts/FontHelper.cs
+++ b/src/XUnity.AutoTranslator.Plugin.Core/Fonts/FontHelper.cs
@@ -31,8 +31,12 @@ namespace XUnity.AutoTranslator.Plugin.Core.Fonts
             }
             else
             {
+#if IL2CPP
+               return GetTextMeshProFontByCustomProxies( assetBundle );
+#else
                XuaLogger.AutoTranslator.Error( "Could not find an appropriate asset bundle load method while loading font: " + overrideFontPath );
                return null;
+#endif
             }
 
             if( bundle == null )


### PR DESCRIPTION
This PR is part of a split from a larger PR, as requested in review.

Fixes an issue where the following error occurs in some games:

"Could not find an appropriate asset bundle load method"

Changes:
- Add IL2CPP-specific fallback in FontHelper
- Use GetTextMeshProFontByCustomProxies when default loading is unavailable

Based on discussion in #720 (credit to @sorrowfoxmoil and @chaos-synthesis).

Notes:
- This change only affects IL2CPP
- Existing behavior for non-IL2CPP remains unchanged