### PR TITLE
Allow user to specify system name font in OverrideFontTextMeshPro option

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,11 @@ The configuratiaon `EnableUIResizing` and `ForceUIResizing` also control whether
 When translating to languages that use non-ASCII letters the game's default font might not be able to display some of those characters. This is the most common when translating to Chinese. To fix this you can supply your own ccustom font that will be used to display the missing characters (or all text in the game).
 
  * `OverrideFont`: Changes the font of all text components. UGUI only.
- * `OverrideFontTextMeshPro`: Consider using `FallbackFontTextMeshPro` instead. Changes the font of all text components regardless of `EnableUIResizing` and `ForceUIResizing`. TextMeshPro only. This option is able to load a font in two different ways. If the specified string indicates a path within the game folder, then that file will be attempted to be loaded as an asset bundle (requires Unity 2018 or greater (or alternatively a custom asset bundle built specifically for the targeted game)). If not, it will be attempted to be loaded through the Resources API. Default resources that are often distributed with TextMeshPro are: `Fonts & Materials/LiberationSans SDF` or `Fonts & Materials/ARIAL SDF`.
+ * `OverrideFontTextMeshPro`: Consider using `FallbackFontTextMeshPro` instead. Changes the font of all text components regardless of `EnableUIResizing` and `ForceUIResizing`. TextMeshPro only.
+     This option is able to load a font in three different ways:
+     1. If the specified string indicates a path within the game folder, then that file will be attempted to be loaded as an asset bundle. Requires a custom asset bundle built specifically for the targeted game.
+     2. If the specified string matches name of a font installed on the system (e.g. Arial), the font will be attempted to be loaded as a TMP font. Requires TextMeshPro 3.2.0+ (see #854).
+     3. Otherwise, the string will be used to attempt to load a font through the Resources API. Default resources that are often distributed with TextMeshPro are: `Fonts & Materials/LiberationSans SDF` or `Fonts & Materials/ARIAL SDF`.
  * `FallbackFontTextMeshPro`: Adds a fallback font that TextMesh Pro can use in case a specific character is not supported.
 
 These settings are not affected by `EnableUIResizing` and `ForceUIResizing`, but the resizing behavior may change how the custom font is displayed.

--- a/src/XUnity.AutoTranslator.Plugin.Core/Fonts/FontHelper.cs
+++ b/src/XUnity.AutoTranslator.Plugin.Core/Fonts/FontHelper.cs
@@ -69,28 +69,37 @@ namespace XUnity.AutoTranslator.Plugin.Core.Fonts
          }
          else
          {
-            string[] systemFontNames = GetOSInstalledFontNames();
             bool isAssetBundleNameInsideSystemFont = false;
-            for( int i = 0; i < systemFontNames.Length; i++ )
+            try
             {
-               if( systemFontNames[ i ] == assetBundle )
+               string[] systemFontNames = GetOSInstalledFontNames();
+               for( int i = 0; i < systemFontNames.Length; i++ )
                {
-                  isAssetBundleNameInsideSystemFont = true;
+                  if( systemFontNames[ i ] == assetBundle )
+                  {
+                     isAssetBundleNameInsideSystemFont = true;
+                     break;
+                  }
                }
             }
-
-            if( isAssetBundleNameInsideSystemFont )
+            catch( Exception ex )
             {
-               XuaLogger.AutoTranslator.Info( "The font name is installed on the system. Attempting to create TextMesh Pro font." );
+               XuaLogger.AutoTranslator.Error( $"Unable to fetch installed font names: {ex.Message}" );
+            }
 
-               if( UnityTypes.TMP_FontAsset_Methods.CreateFontAsset != null )
-               {
-                  font = (UnityEngine.Object)UnityTypes.TMP_FontAsset_Methods.CreateFontAsset.Invoke( null, new object[] { assetBundle, "", 90 } );
-                  XuaLogger.AutoTranslator.Info( $"TextMeshPro font from '{assetBundle}' created successfully." );
-               }
+            if( UnityTypes.TMP_FontAsset_Methods.CreateFontAsset != null && isAssetBundleNameInsideSystemFont )
+            {
+               XuaLogger.AutoTranslator.Info( "The asset bundle name is installed on the system. Attempting to create TextMesh Pro font." );
+               font = (UnityEngine.Object)UnityTypes.TMP_FontAsset_Methods.CreateFontAsset.Invoke( null, new object[] { assetBundle, "", 90 } );
             }
             else
             {
+               if( UnityTypes.TMP_FontAsset_Methods.CreateFontAsset == null )
+               {
+                  XuaLogger.AutoTranslator.Warn( "TMP_FontAsset.CreateFontAsset not found. TextMeshPro version might be below 3.2.0." );
+               }
+
+               XuaLogger.AutoTranslator.Info( "Attempting to load TextMesh Pro font from internal Resources API." );
                font = Resources.Load( assetBundle );
             }
          }
@@ -125,7 +134,7 @@ namespace XUnity.AutoTranslator.Plugin.Core.Fonts
          if( File.Exists( overrideFontPath ) )
          {
             XuaLogger.AutoTranslator.Info( "Attempting to load TextMesh Pro font from asset bundle." );
-            
+
             var bundle = AssetBundleProxy.LoadFromFile( overrideFontPath );
 
             if( bundle == null )

--- a/src/XUnity.AutoTranslator.Plugin.Core/Fonts/FontHelper.cs
+++ b/src/XUnity.AutoTranslator.Plugin.Core/Fonts/FontHelper.cs
@@ -89,7 +89,7 @@ namespace XUnity.AutoTranslator.Plugin.Core.Fonts
 
             if( UnityTypes.TMP_FontAsset_Methods.CreateFontAsset != null && isAssetBundleNameInsideSystemFont )
             {
-               XuaLogger.AutoTranslator.Info( "The asset bundle name is installed on the system. Attempting to create TextMesh Pro font." );
+               XuaLogger.AutoTranslator.Info( $"A font {assetBundle} is installed on the system. Attempting to create a TextMesh Pro font from it." );
                font = (UnityEngine.Object)UnityTypes.TMP_FontAsset_Methods.CreateFontAsset.Invoke( null, new object[] { assetBundle, "", 90 } );
             }
             else

--- a/src/XUnity.AutoTranslator.Plugin.Core/Fonts/FontHelper.cs
+++ b/src/XUnity.AutoTranslator.Plugin.Core/Fonts/FontHelper.cs
@@ -69,9 +69,30 @@ namespace XUnity.AutoTranslator.Plugin.Core.Fonts
          }
          else
          {
-            XuaLogger.AutoTranslator.Info( "Attempting to load TextMesh Pro font from internal Resources API." );
+            string[] systemFontNames = GetOSInstalledFontNames();
+            bool isAssetBundleNameInsideSystemFont = false;
+            for( int i = 0; i < systemFontNames.Length; i++ )
+            {
+               if( systemFontNames[ i ] == assetBundle )
+               {
+                  isAssetBundleNameInsideSystemFont = true;
+               }
+            }
 
-            font = Resources.Load( assetBundle );
+            if( isAssetBundleNameInsideSystemFont )
+            {
+               XuaLogger.AutoTranslator.Info( "The font name is installed on the system. Attempting to create TextMesh Pro font." );
+
+               if( UnityTypes.TMP_FontAsset_Methods.CreateFontAsset != null )
+               {
+                  font = (UnityEngine.Object)UnityTypes.TMP_FontAsset_Methods.CreateFontAsset.Invoke( null, new object[] { assetBundle, "", 90 } );
+                  XuaLogger.AutoTranslator.Info( $"TextMeshPro font from '{assetBundle}' created successfully." );
+               }
+            }
+            else
+            {
+               font = Resources.Load( assetBundle );
+            }
          }
 
          if( font != null )

--- a/src/XUnity.Common/Constants/UnityTypes.cs
+++ b/src/XUnity.Common/Constants/UnityTypes.cs
@@ -336,6 +336,11 @@ namespace XUnity.Common.Constants
 #endif
       }
 
+      public static class TMP_FontAsset_Methods
+      {
+         public static CachedMethod CreateFontAsset = UnityTypes.TMP_FontAsset?.ClrType.CachedMethod( "CreateFontAsset", typeof( string ), typeof( string ), typeof( int ) );
+      }
+
       public static class TMP_Text_Methods
       {
 #if IL2CPP
@@ -569,8 +574,8 @@ namespace XUnity.Common.Constants
             {
                var nativeType = ptr != IntPtr.Zero ? Il2CppType.TypeFromPointer( ptr ) : Il2CppType.From( wrapperType );
 
-               if (nativeType == null)
-               {    
+               if( nativeType == null )
+               {
                   XuaLogger.AutoTranslator.Warn( "Could not find '" + name + "' in IL2CPP domain even though it could be found in the managed domain." );
                }
 


### PR DESCRIPTION
Related Issue: #853 

## Description

This pr changes:
- Add reflection to `TMP_FontAsset.CreateFontAsset(string, string, int)` function
- When `FontHelper` class cannot find assetbundle, it searches system fonts instead. If name is matched, it creates TMP_FontAsset based on the system font.

## How to test

1. Modify OverrideFontTextMeshPro configuration
```diff
[Behaviour]
- OverrideFontTextMeshPro=
+ OverrideFontTextMeshPro=Microsoft YaHei
```
2. Open the game and test if the font is overrode.

## Potential Problems

`TMP_FontAsset.CreateFontAsset(string, string, int)` is added in TextMeshPro 3.2.0. Before this version, we can use this method instead:
```cs
Font __font = new Font("/path/to/systemfont.ttf");
TMP_FontAsset tmpFont = TMP_FontAsset.CreateFontAsset(__font);
```
However, I don't know how to create reflection for overloaded function. Also, I cannot decide where the user should put the path.